### PR TITLE
Fixed output file name

### DIFF
--- a/ust.cpp
+++ b/ust.cpp
@@ -142,7 +142,7 @@ string getFileName(const string& s) {
       return(s.substr(i+1, s.length() - i));
    }
 
-   return("");
+   return s;
 }
 
 


### PR DESCRIPTION
Before this if the source file does not contain any `/` (i.e. it is in the current location folder) the output file was named `.ust.fa` resulting invisible.

This was because the input file name reader looks for the name after the last `/` in the path. If a `/` cannot be found it used to return an empty string, now with this edit it will return the complete file name.

```C++
string getFileName(const string& s) {
   char sep = '/';
   size_t i = s.rfind(sep, s.length());
   if (i != string::npos) {
      return(s.substr(i+1, s.length() - i));
   }

   // else, if '/' is not in s

   // before: return("");
   // now:
   return s;
}
```